### PR TITLE
remove old ansible-splunk

### DIFF
--- a/requirements.yml
+++ b/requirements.yml
@@ -19,7 +19,3 @@
 
 - src: git+https://github.com/osu-itis/ansible-epel-repository
   name: epel-repository
-
-- src: git+https://github.com/osu-itis/ansible-splunk
-  name: splunk
-


### PR DESCRIPTION
removed old repo from requirements.yml, as it no longer exists
