### PR TITLE
Add role ansible-common-proxy

### DIFF
--- a/common.yml
+++ b/common.yml
@@ -4,6 +4,7 @@
   remote_user: root
   roles:
     - conf-dns
+    - { role: common-proxy, when: "'requires_proxy' in group_names" }
     - { role: common-apt, when: ansible_os_family == 'Debian' }
     - { role: common-yum, when: ansible_os_family == 'RedHat' }
     - { role: disable-selinux, when: ansible_os_family == 'RedHat' }

--- a/requirements.yml
+++ b/requirements.yml
@@ -19,3 +19,6 @@
 
 - src: git+https://github.com/osu-itis/ansible-epel-repository
   name: epel-repository
+
+- src: git+https://github.com/osu-itis/ansible-common-proxy
+  name: common-proxy


### PR DESCRIPTION
Applies proxy role to hosts belonging to the "requires_proxy" inventory group.
